### PR TITLE
Add row count estimates to progress bar #17

### DIFF
--- a/cli/find.php
+++ b/cli/find.php
@@ -121,17 +121,19 @@ if (!$options['summary']) {
 }
 
 // Perform the search.
-[$count, $searchlist] = helper::build_searching_list($tables, $skiptables, $skipcolumns);
+$rowcounts = helper::estimate_table_rows();
+[$totalrows, $searchlist] = helper::build_searching_list($tables, $skiptables, $skipcolumns, '', $rowcounts);
 
 $progress = new progress_bar();
 $progress->create();
 
 // Output the result for each table.
-$columncount = 0;
+$rowcount = 0;
 foreach ($searchlist as $table => $columns) {
     foreach ($columns as $column) {
         // Show the table and column being searched.
         $colname = $column->name;
+        $progress->update($rowcount, $totalrows, "Searching in $table:$colname");
 
         // Perform the search.
         if (!empty($options['regex-match'])) {
@@ -140,8 +142,7 @@ foreach ($searchlist as $table => $columns) {
             helper::plain_text_search($search, $table, $column, $summary, $fp);
         }
 
-        $columncount++;
-        $progress->update_full(100 * $columncount / $count, "Searching in $table:$colname");
+        $rowcount += $rowcounts[$table] ?? 1;
     }
 }
 

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -266,4 +266,23 @@ final class helper_test extends \advanced_testcase {
         $this->assertStringContainsString('https://example.com.au/5678', $updatedpage->content);
     }
 
+    /**
+     * Test for estimate_table_rows
+     *
+     * @covers \tool_advancedreplace\helper::estimate_table_rows
+     */
+    public function test_estimate_table_rows(): void {
+        global $DB;
+
+        $supporteddb = ['mysql', 'postgres'];
+
+        if (in_array($DB->get_dbfamily(), $supporteddb)) {
+            // Confirm the number of estimates match the number of tables.
+            $estimates = helper::estimate_table_rows();
+            $this->assertEquals(count($DB->get_tables()), count($estimates));
+        } else {
+            $this->assertEmpty(helper::estimate_table_rows());
+        }
+    }
+
 }


### PR DESCRIPTION
Closes #17 

From my testing I've noted that while the progress estimate with row counts is more consistent, is can still vary significantly depending on the average amount of text within a column etc.

One other issue is the progress bar message is only updated when there is a visible change in the percent (to 2 d.p.), so the displayed table/column being searched often isn't accurate.