### PR TITLE
Exclude own tables #7

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -36,6 +36,11 @@ class helper {
     /** @var string ALL_COLUMNS Flag to indicate we search all columns in a table **/
     const ALL_COLUMNS = 'all columns';
 
+    /** @var array SKIP_TABLES Additional tables that should always be skipped. Most are already handled by core. **/
+    const SKIP_TABLES = [
+        search::TABLE,
+    ];
+
     /**
      * Get columns to search for in a table.
      *
@@ -170,7 +175,7 @@ class helper {
         }
 
         // Skip tables and columns.
-        $skiptables = explode(',', $skiptables);
+        $skiptables = array_merge(self::SKIP_TABLES, explode(',', $skiptables));
         $skipcolumns = explode(',', $skipcolumns);
 
         // Return the list of tables and actual columns to search.


### PR DESCRIPTION
- Adds a new field that specifies tables to be skipped

Closes #7  - this should be enough since I believe the core tables are already handled by the check on db_should_replace() when building the search list.