### PR TITLE
Make search whitespace more visible

### DIFF
--- a/classes/search_table.php
+++ b/classes/search_table.php
@@ -142,6 +142,18 @@ class search_table extends \table_sql {
     }
 
     /**
+     * Formats content for the search column.
+     *
+     * @param stdClass $record
+     * @return string
+     */
+    public function col_search(stdClass $record): string {
+        $class = 'border p-1 d-inline';
+        $style = 'white-space: pre-wrap;';
+        return \html_writer::tag('pre', $record->search, ['class' => $class, 'style' => $style]);
+    }
+
+    /**
      * Generate content for progress column.
      *
      * @param stdClass $record


### PR DESCRIPTION
Searches for both regular text and regex can contain whitespace, but it's also easy to accidentally include whitespace when copying search terms.

Ideally this would be visible on both the search form and search table.