### PR TITLE
Update unit test regex

### DIFF
--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -325,7 +325,7 @@ final class helper_test extends \advanced_testcase {
     public function test_regex_search(): void {
         $this->resetAfterTest();
 
-        $searchstring = "https://example.com.au/\d+";
+        $searchstring = "https://example.com.au/[0-9]+";
 
         // Create a course.
         $course = $this->getDataGenerator()->create_course();


### PR DESCRIPTION
```
There was 1 error:

1) tool_advancedreplace\helper_test::test_regex_search
Undefined index: page

/var/www/site/admin/tool/advancedreplace/tests/helper_test.php:370
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/site/vendor/phpunit/phpunit/phpunit:97
```

The previous regex was not compatible with older versions of mysql (like 5.7), which was causing this error in a few environments. There should be no harm in changing the regex to a simplified version.