### PR TITLE
Added mtrace debugging for better visibility

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -499,10 +499,18 @@ class helper {
         $update = new \stdClass();
         $update->time = time();
         $update->percent = 0;
+
+        $tablec = 0;
+        $columnc = 0;
+
         foreach ($searchlist as $table => $columns) {
+            $tablec++;
             foreach ($columns as $column) {
                 $colname = $column->name;
                 $colstart = time();
+
+                mtrace("Searching in $table:$colname");
+                $columnc++;
 
                 // Show the table and column being searched.
                 $search->update_progress_bar("Searching in $table:$colname");
@@ -534,6 +542,7 @@ class helper {
             }
         }
 
+        mtrace("Searched in $columnc columns across $tablec tables");
         fclose($fp);
 
         // Display log output.


### PR DESCRIPTION
Example:
```
Execute adhoc task: tool_advancedreplace\task\search_db
Adhoc task id: 711
Adhoc task custom data: {"searchid":4}
... started 16:16:10. Current memory use 18.6 MB.
Searching in user:address
Searching in user:alternatename
Searching in user:auth
Searching in user:calendartype
Searching in user:city
Searching in user:department
Searching in user:description
Searching in user:email
Searching in user:firstname
Searching in user:firstnamephonetic
Searching in user:idnumber
Searching in user:imagealt
Searching in user:institution
Searching in user:lang
Searching in user:lastip
Searching in user:lastname
Searching in user:lastnamephonetic
Searching in user:middlename
Searching in user:moodlenetprofile
Searching in user:password
Searching in user:phone1
Searching in user:phone2
Searching in user:secret
Searching in user:theme
Searching in user:timezone
Searching in user:username
Searched in 26 columns across 1 tables
... used 108 dbqueries
... used 0.14813113212585 seconds
... used 24.7 MB peak memory
Adhoc task complete: tool_advancedreplace\task\search_db
```