### PR TITLE
Issue #140: Added explicit parameters for str_getcsv()

### DIFF
--- a/classes/file_search.php
+++ b/classes/file_search.php
@@ -639,7 +639,7 @@ class file_search {
      */
     public static function get_id_from_csv(string $line): int {
         // Interpret the last line as a csv line.
-        $csv = str_getcsv($line);
+        $csv = str_getcsv($line, ",", "\"", "\\");
         // Check a few columns to ensure we have a valid line.
         if (empty($csv[self::CSV_CONTEXTID])) {
             return 0;


### PR DESCRIPTION
Closes issue #105.

Updated `file_search::get_id_from_csv` to call `str_getcsv()` with explicit parameters to fix deprecation warnings during unit tests.

## Environment
```
- Moodle 5.1.5+ (Build: 20260714)
- PHP: 8.4.22
- DB: MySQL 8.4
- PHPUnit: 11.5.55
- Branch: MOODLE_401_STABLE
```

## Testing instructions:
- `tool_advancedreplace` test suite: `vendor/bin/phpunit --testsuite tool_advancedreplace_testsuite`
- Running the unit tests for `tool_advancedreplace` will produce the following warning (on the above environment):
```
Moodle 5.1.5+ (Build: 20260714)
Php: 8.4.22, mysqli: 8.4.10, OS: Linux 6.17.0-1028-oem x86_64
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-plugins/phpunit.xml

............DDDD.DDDDD..............S....                         41 / 41 (100%)

Time: 00:06.373, Memory: 82.50 MB

9 tests triggered 1 PHP deprecation:

1) /var/www/upstream-plugins/public/admin/tool/advancedreplace/classes/file_search.php:642
str_getcsv(): the $escape parameter must be provided as its default value will change

Triggered by:

* tool_advancedreplace\file_search_test::test_get_id_from_csv#0
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:213

* tool_advancedreplace\file_search_test::test_get_id_from_csv#1
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:213

* tool_advancedreplace\file_search_test::test_get_id_from_csv#2
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:213

* tool_advancedreplace\file_search_test::test_get_id_from_csv#3
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:213

* tool_advancedreplace\file_search_test::test_resume#1 (2 times)
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:269

* tool_advancedreplace\file_search_test::test_resume#2 (2 times)
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:269

* tool_advancedreplace\file_search_test::test_resume#3 (3 times)
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:269

* tool_advancedreplace\file_search_test::test_resume#4 (3 times)
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:269

* tool_advancedreplace\file_search_test::test_resume#5 (2 times)
  /var/www/upstream-plugins/public/admin/tool/advancedreplace/tests/file_search_test.php:269

OK, but there were issues!
Tests: 41, Assertions: 145, Deprecations: 1, PHPUnit Deprecations: 10, Skipped: 1.
```
### Expected Output from PHPUnit Tests
- Pulling this branch `MOODLE_404_STABLE-issue105` and re-running the testsuite:
```
Moodle 5.1.5+ (Build: 20260714)
Php: 8.4.22, mysqli: 8.4.10, OS: Linux 6.17.0-1028-oem x86_64
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-plugins/phpunit.xml

....................................S....                         41 / 41 (100%)

Time: 00:06.244, Memory: 80.50 MB

OK, but there were issues!
Tests: 41, Assertions: 145, PHPUnit Deprecations: 10, Skipped: 1.
```